### PR TITLE
Code fixing issue 4

### DIFF
--- a/source/shell_scripts/number_of_tasks.sh
+++ b/source/shell_scripts/number_of_tasks.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
+run_env="$(uname)"
+
 if [ -z $SLURM_NPROCS ]
 then
-     N_tasks=$(nproc)
-     N_cpus_per_task="1"
+	if [[ $run_env =~ "Darwin" ]]; then
+		N_tasks=$(sysctl -n hw.logicalcpu)
+	else
+		N_tasks=$(nproc)
+	fi
+    N_cpus_per_task="1"
 else
-     N_tasks=$SLURM_NPROCS
-     N_cpus_per_task=$SLURM_CPUS_PER_TASK
+    N_tasks=$SLURM_NPROCS
+    N_cpus_per_task=$SLURM_CPUS_PER_TASK
 fi
 
 echo "${N_tasks},${N_cpus_per_task}"


### PR DESCRIPTION
I believe this pull request fixes the issue I raise in issue 4 [here ](https://github.com/AarhusCosmology/connect_public/issues/4). The segmentation fault was not due to the MPI communication as I initially thought, but rather came when the code tried to access the class instance. This is because the initialization of `cosmo` in line 230 of the original file assumes the user is using CLASS++, which is not always the case. If the user is using something else, `cosmo` is not properly initialized, and trying to access computed quantities such as the Cl's causes a segmentation fault. Namely, the parameters are not appropriately passed, and there is never a call to `cosmo.compute()`. My changes should fix this for either case, assuming CLASS++ is backwards compatible with the syntax of  'normal' CLASS.

Also included in this pull request is a minor change to `number_of_tasks.sh` to make it compatible for Macs. `$(nprocs)` is a Linux only command.