### PR TITLE
Added methods directly to trained models and made matter power spectr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mcmc_plugin/connect.conf
 !/input/example.param
 !/jobscripts/example.js
 .DS_Store
+._.DS_Store

--- a/source/Splines.py
+++ b/source/Splines.py
@@ -1,0 +1,81 @@
+import tensorflow as tf
+
+class Spline():
+    def __init__(self, x, x_target):
+        self.h = tf.experimental.numpy.diff(x)
+        self.n = x.shape[0]
+        self.a = tf.stack([self.h[i] / (self.h[i] + self.h[i + 1]) for i in range(self.n - 2)] + [0], axis=0)
+        self.b = tf.scalar_mul(2, tf.ones(x.shape[0]))
+        self.c = tf.stack([0] + [self.h[i + 1] / (self.h[i] + self.h[i + 1]) for i in range(self.n - 2)], axis=0)
+        self.diagonals = (self.c, self.b, self.a)
+        self.x = x
+        self.x_target = x_target
+
+        # Initialize interval as an empty tensor with the correct shape
+        self.interval = tf.TensorArray(tf.int32, size=self.n - 1)
+
+        # Define the loop body
+        def loop_body(i, interval):
+            def true_fn_0(interval):
+                start = tf.where(x_target < x[i + 1])[0, 0]
+                end = tf.where(x_target < x[i + 1])[-1, 0] + 1
+                interval = interval.write(i, [start, end])
+                return i + 1, interval
+
+            def true_fn_last(interval):
+                start = tf.where(x_target >= x[i])[0, 0]
+                end = tf.where(x_target >= x[i])[-1, 0] + 1
+                interval = interval.write(i, [start, end])
+                return i + 1, interval
+
+            def false_fn(interval):
+                boolean_array = tf.logical_and(x_target >= x[i], x_target < x[i + 1])
+                start = tf.where(boolean_array)[0, 0]
+                end = tf.where(boolean_array)[-1, 0] + 1
+                interval = interval.write(i, [start, end])
+                return i + 1, interval
+
+            i, interval = tf.cond(
+                tf.equal(i, 0),
+                lambda: true_fn_0(interval),
+                lambda: tf.cond(tf.equal(i, self.n - 2), lambda: true_fn_last(interval), lambda: false_fn(interval))
+            )
+
+            return i, interval
+
+        # Define the loop condition
+        def loop_cond(i, interval):
+            return i < self.n - 1
+
+        # Initialize the loop variables
+        i = tf.constant(0)
+
+        # Run the loop
+        _, interval = tf.while_loop(loop_cond, loop_body, [i, self.interval])
+
+        # Convert the TensorArray to a Tensor
+        self.interval = interval.stack()
+
+    @tf.function
+    def do_spline(self, y):
+        y_res = []
+        yp = tf.pad(y[:, 1:  ], tf.constant([[0,0],[0,1]]), constant_values=1)
+        ym = tf.pad(y[:,  :-1], tf.constant([[0,0],[1,0]]), constant_values=1)
+        hp = tf.pad(self.h,  tf.constant([[0,1]]), constant_values=1)
+        hm = tf.pad(self.h,  tf.constant([[1,0]]), constant_values=1)
+
+        rhs = (yp-y)/hp - (y-ym)/hm
+        rhs /= hp+hm
+        rhs *= 6
+
+        rhs = tf.pad(rhs[:, 1:-1],tf.constant([[0,0],[1,1]]))
+        X = tf.transpose(tf.linalg.tridiagonal_solve(self.diagonals, tf.transpose(rhs), diagonals_format='sequence'))
+        for i in range(self.n-1):
+            C = tf.concat([[(X[:,i+1]-X[:,i])*self.h[i]*self.h[i]/6],
+                            [X[:,i]*self.h[i]*self.h[i]/2],
+                            [(y[:,i+1] - y[:,i] - (X[:,i+1]+2*X[:,i])*self.h[i]*self.h[i]/6)],
+                            [y[:,i]]],0)
+            z = tf.divide(tf.subtract(self.x_target[self.interval[i,0]:self.interval[i,1]],self.x[i]),self.h[i])
+            Z = tf.concat([[tf.pow(z,3)],[tf.pow(z,2)],[tf.pow(z,1)],[tf.pow(z,0)]],0)
+            y_res.append(tf.linalg.matmul(C,Z,transpose_a=True))
+        return tf.concat(y_res,1)

--- a/source/calc_models_mpi.py
+++ b/source/calc_models_mpi.py
@@ -209,7 +209,7 @@ else:
             if not 'P_k_max_1/Mpc' in params:
                 params['P_k_max_1/Mpc'] = 1.
 
-        signal.alarm(200) # CLASS computations must not take longer than 200 seconds
+        signal.alarm(param.max_time_for_theory) # CLASS computations must not take longer than this amount of seconds (default is 200)
         try:
             cosmo = classy.Class()
             cosmo.set(params)

--- a/source/data_sampling.py
+++ b/source/data_sampling.py
@@ -128,6 +128,10 @@ class Sampling():
                 N_accepted = mcmc.discard_oversampled_points(i)
                 N_in_data_set = mcmc.get_number_of_data_points(i-1) + N_accepted
                 print(f"Accepted {N_accepted} points out of {N_keep}", flush=True)
+            elif i == 1 and self.param.keep_initial_data:
+                N_accepted = mcmc.discard_oversampled_points(i)
+                N_in_data_set = mcmc.get_number_of_data_points(i-1) + N_accepted
+                print(f"Accepted {N_accepted} points out of {N_keep}", flush=True)
             else:
                 N_accepted=N_keep
                 N_in_data_set = 0
@@ -152,6 +156,9 @@ class Sampling():
             if i > int(not self.param.keep_first_iteration) + 1 and i <= i_converged:
                 combine_iterations_data(self.param, i)
                 print(f"Copied data from data/{self.param.jobname}/number_{i-1} into data/{self.param.jobname}/number_{i}", flush=True)
+            elif i == 1 and self.param.keep_initial_data:
+                combine_iterations_data(self.param, i)
+                print(f"Copied data from data/{self.param.jobname}/N-{self.param.N} into data/{self.param.jobname}/number_{i}", flush=True)
 
             print("Training neural network", flush=True)
             model = self.train_neural_network(sampling='iterative',
@@ -180,10 +187,10 @@ class Sampling():
         self.param.param_file = self.CONNECT_PATH+'/'+self.data_path+'/log_connect.param'
 
     def call_calc_models(self, sampling='lhc'):
-        os.environ["export OMP_NUM_THREADS"] = str({self.N_cpus_per_task})
+        os.environ["OMP_NUM_THREADS"] = str({self.N_cpus_per_task})
         os.environ["PMIX_MCA_gds"] = "hash"
         sp.check_call(f"mpirun -np {self.N_tasks - 1} python {self.CONNECT_PATH}/source/calc_models_mpi.py {self.param.param_file} {self.CONNECT_PATH} {sampling}".split())
-        os.environ["export OMP_NUM_THREADS"] = "1"
+        os.environ["OMP_NUM_THREADS"] = "1"
 
     def train_neural_network(self, sampling='lhc', output_file=None):
         if sampling in ['lhc','hypersphere','pickle']:

--- a/source/ini_samplers.py
+++ b/source/ini_samplers.py
@@ -58,7 +58,7 @@ class HypersphereSampler():
         self.rng = np.random.default_rng(seed=seed)
         if param.hypersphere_covmat is not None:
             cov_file = param.hypersphere_covmat
-            cov = get_covmat(cov_file, param)
+            cov = get_covmat(cov_file, param) * fac
             self.L = np.linalg.cholesky(cov)
 
         self.bounds = np.array(list(self.parameters.values()))

--- a/source/mcmc_base.py
+++ b/source/mcmc_base.py
@@ -109,7 +109,10 @@ class MCMC_base_class():
                                    iteration         # Current iteration number
                                ):
 
-        file_old_data = f"data/{self.param.jobname}/number_{iteration-1}/model_params.txt"
+        if iteration-1 == 0:
+            file_old_data = f"data/{self.param.jobname}/N-{self.param.N}/model_params.txt"
+        else:
+            file_old_data = f"data/{self.param.jobname}/number_{iteration-1}/model_params.txt"
         points1, points2 = self.import_points_to_compare(file_old_data, iteration)
 
         num_points_in_vicinity = 10
@@ -196,5 +199,9 @@ class MCMC_base_class():
                                   iteration   # Iteration number
                               ):
 
-        with open(os.path.join(self.CONNECT_PATH, f'data/{self.param.jobname}/number_{iteration}/model_params.txt'), 'r') as f:
+        if iteration == 0:
+            folder = f"N-{self.param.N}"
+        else:
+            folder = f"number_{iteration}"
+        with open(os.path.join(self.CONNECT_PATH, f'data/{self.param.jobname}/{folder}/model_params.txt'), 'r') as f:
             return len(list(f)) - 1

--- a/source/tools.py
+++ b/source/tools.py
@@ -179,7 +179,10 @@ def combine_iterations_data(param,             # Parameter object
                         ):
 
     path_i = os.path.join(CONNECT_PATH, f'data/{param.jobname}/number_{iter_num}')
-    path_j = os.path.join(CONNECT_PATH, f'data/{param.jobname}/number_{iter_num-1}')
+    if iter_num-1 == 0:
+        path_j = os.path.join(CONNECT_PATH, f'data/{param.jobname}/N-{param.N}')
+    else:
+        path_j = os.path.join(CONNECT_PATH, f'data/{param.jobname}/number_{iter_num-1}')
     combine_sets_of_data_files(os.path.join(path_i, 'model_params.txt'),
                                os.path.join(path_j, 'model_params.txt'))
     if len(param.output_derived) > 0:

--- a/source/train_network.py
+++ b/source/train_network.py
@@ -412,6 +412,11 @@ class Training():
             stdout_backup = sys.stdout
             sys.stdout = open(output_file, 'w')
 
+        if 'ell' in self.output_info:
+            ell_computed = self.output_info['ell']
+        else:
+            ell_computed = [2,3,4,5]
+
         with self.training_strategy:
 
             self.model = Dense_model(self.param.N_nodes, 
@@ -420,7 +425,8 @@ class Training():
                                      input_normaliser=self.input_normaliser,
                                      output_unnormaliser=self.unnormalise,
                                      activation=self.param.activation_function,
-                                     num_hidden_layers=self.param.N_hidden_layers)
+                                     num_hidden_layers=self.param.N_hidden_layers,
+                                     ell_computed=ell_computed)
             
             self.model.compile(optimizer=adam,
                                loss=self.loss_fun)


### PR DESCRIPTION
Added methods directly to the trained Keras models. These include `get_cls`, `get_cls_interp`, `get_Pks`, and `get_derived`, which allows the user to get power spectra and derived parameters directly from the model without having to use the wrapper.

Methods mimicking how output related to the matter power spectrum is obtained from `class` has been added to the wrapper in order to use different likelihood codes relying on these calls.